### PR TITLE
fix COPY error

### DIFF
--- a/2021/blitz/Dockerfile
+++ b/2021/blitz/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +s /home/blitz/runner
 RUN rm /home/blitz/runner.c
 
 
-COPY *.txt /home/blitz
+COPY *.txt /home/blitz/
 
 WORKDIR /home/blitz
 


### PR DESCRIPTION
Сборка таска `blitz` падает из-за отсутствия слэша в директории для COPY

![image](https://github.com/vsfi/bashwars/assets/34795180/e1e4aebc-5b40-4ee5-a518-a1f30a58ffee)
